### PR TITLE
Modified GeneratesIds.php

### DIFF
--- a/src/Database/Concerns/GeneratesIds.php
+++ b/src/Database/Concerns/GeneratesIds.php
@@ -11,8 +11,8 @@ trait GeneratesIds
     public static function bootGeneratesIds()
     {
         static::creating(function (self $model) {
-            if (! $model->getTenantKey() && $model->shouldGenerateId()) {
-                $model->setAttribute($model->getTenantKeyName(), app(UniqueIdentifierGenerator::class)->generate($model));
+            if (!$model->getKey() && $model->shouldGenerateId()) {
+                $model->setAttribute($model->getKeyName(), app(UniqueIdentifierGenerator::class)->generate($model));
             }
         });
     }


### PR DESCRIPTION
When overwriting `getTenantKeyName()` to use another column, an exception occurs when creating new tenants. (Field 'id' doesn't have a default value).

This fixes the issue.